### PR TITLE
Remove obsolete 'compile' gradle configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'org.tensorflow:tensorflow-lite:+'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'org.tensorflow:tensorflow-lite:+'
 }
-  


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
For more information see: http://d.android.com/r/tools/update-dependency-configurations.html

